### PR TITLE
feat: add aws_accessanalyzer_analyzer for external analysis

### DIFF
--- a/modules/accessanalyzer/main.tf
+++ b/modules/accessanalyzer/main.tf
@@ -1,0 +1,4 @@
+resource "aws_accessanalyzer_analyzer" "accessanalyzer-external" {
+  analyzer_name = "amaani-accessanalyzer-external"
+  type          = "ACCOUNT"
+}


### PR DESCRIPTION
This commit adds a new aws_accessanalyzer_analyzer resource to modules/accessanalyzer/main.tf for external account analysis.